### PR TITLE
Fix bug in PENMANCodec._layout method

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,12 @@ NodeType <- Atom
 Variable <- Atom
 Edge     <- Relation Value
 Relation <- /:[^\s(]*/
-Value    <- Node | String | Float | Integer | Atom
+Value    <- Node | Atom
+Atom     <- String | Float | Integer | Symbol
 String   <- /"[^"\\]*(?:\\.[^"\\]*)*"/
-Atom     <- /[^\s)\/]+/
 Float    <- /[-+]?(0|[1-9]\d*)(\.\d+[eE][-+]?|\.|[eE][-+]?)\d+/
 Integer  <- /[-+]?\d+/
+Symbol   <- /[^\s)\/]+/
 ```
 
 \* *Note: I use `|` above for ordered-choice instead of `/` so that `/`

--- a/penman.py
+++ b/penman.py
@@ -482,7 +482,7 @@ class PENMANCodec(object):
         for t in outedges:
             if t.relation == self.TYPE_REL:
                 if t.target is not None:
-                    branches = ['/ ' + t.target] + branches  # always first
+                    branches = ['/ {}'.format(t.target)] + branches  # always first
             else:
                 if t.inverted:
                     tgt = t.source


### PR DESCRIPTION
Bug is in line 485. The operation `'/ ' + t.target` throws `TypeError: cannot concatenate 'str' and 'int' objects` when the concept of a node is a number, although this is allowed by the grammar.