### PR TITLE
Fix flaky tests/test_layout.py::test_rearrange

### DIFF
--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -50,6 +50,7 @@ def test_interpret(amr_model):
 
 
 def test_rearrange():
+    random.seed(1)
     t = codec.parse('''
         (a / alpha
            :ARG0 (b / beta


### PR DESCRIPTION
This PR aims to fix the flaky test `tests/test_layout.py::test_rearrange`. In previous versions, the test will run into randomly in `rearrange(t, model.random_order)` case. And the reason is that the globally defined `random.seed(1)` seems not working well here, so I define the seed inside that test case. The test failure can be reproduced by running `pytest` possibly for multiple times.
Notice that the PR is modifying the test to make it more robust without changing the source code.