### PR TITLE
Encoding generalizations

### DIFF
--- a/penman/__main__.py
+++ b/penman/__main__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import locale
 import sys
 import os
 import argparse
@@ -222,12 +222,16 @@ def main():
         '--indicate-branches', action='store_true',
         help='insert triples to indicate tree structure')
 
+    norm.add_argument(
+        '--encoding', action='store_true', default=locale.getpreferredencoding(),
+        help='encoding to use for input/output. Defaults to system default')
+
     args = parser.parse_args()
 
     if args.quiet:
         args.verbosity = 0
         sys.stdout.close()
-        sys.stdout = open(os.devnull, 'w')
+        sys.stdout = open(os.devnull, 'w', encoding=args.encoding)
     else:
         args.verbosity = min(args.verbosity, 3)
 
@@ -264,7 +268,7 @@ def main():
 
     if args.FILE:
         for file in args.FILE:
-            with open(file) as f:
+            with open(file, encoding=args.encoding) as f:
                 exitcode = process(
                     f, model, sys.stdout, sys.stderr, args.check,
                     normalize_options, format_options, args.triples)

--- a/penman/__main__.py
+++ b/penman/__main__.py
@@ -229,7 +229,7 @@ def main():
     if args.quiet:
         args.verbosity = 0
         sys.stdout.close()
-        sys.stdout = open(os.devnull, 'w')
+        sys.stdout = open(os.devnull, 'w', encoding='utf-8')
     else:
         args.verbosity = min(args.verbosity, 3)
 

--- a/penman/__main__.py
+++ b/penman/__main__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import locale
 import sys
 import os
 import argparse
@@ -170,6 +169,9 @@ def main():
     parser.add_argument(
         'FILE', nargs='*',
         help='read graphs from FILEs instead of stdin')
+    parser.add_argument(
+        '--encoding', default=None,
+        help='encoding to use for input/output. Defaults to system default')
     model_group = parser.add_mutually_exclusive_group()
     model_group.add_argument(
         '--model', metavar='FILE',
@@ -222,16 +224,12 @@ def main():
         '--indicate-branches', action='store_true',
         help='insert triples to indicate tree structure')
 
-    norm.add_argument(
-        '--encoding', action='store_true', default=locale.getpreferredencoding(),
-        help='encoding to use for input/output. Defaults to system default')
-
     args = parser.parse_args()
 
     if args.quiet:
         args.verbosity = 0
         sys.stdout.close()
-        sys.stdout = open(os.devnull, 'w', encoding=args.encoding)
+        sys.stdout = open(os.devnull, 'w')
     else:
         args.verbosity = min(args.verbosity, 3)
 

--- a/penman/codec.py
+++ b/penman/codec.py
@@ -3,7 +3,7 @@
 """
 Serialization of PENMAN graphs.
 """
-from typing import Union, Iterable, Iterator, List, IO
+from typing import Optional, Union, Iterable, Iterator, List, IO
 from pathlib import Path
 
 from penman.types import (

--- a/penman/codec.py
+++ b/penman/codec.py
@@ -3,7 +3,6 @@
 """
 Serialization of PENMAN graphs.
 """
-import locale
 from typing import Union, Iterable, Iterator, List, IO
 from pathlib import Path
 
@@ -242,7 +241,7 @@ def _encode(g: Graph,
 
 def _load(source: FileOrFilename,
           model: Model = None,
-          encoding: str = locale.getpreferredencoding()) -> List[Graph]:
+          encoding: Optional[str] = None) -> List[Graph]:
     """
     Deserialize a list of PENMAN-encoded graphs from *source*.
 
@@ -281,7 +280,7 @@ def _dump(graphs: Iterable[Graph],
           model: Model = None,
           indent: Union[int, bool] = -1,
           compact: bool = False,
-          encoding: str = locale.getpreferredencoding()) -> None:
+          encoding: Optional[str] = None) -> None:
     """
     Serialize each graph in *graphs* to PENMAN and write to *file*.
 

--- a/penman/codec.py
+++ b/penman/codec.py
@@ -3,7 +3,7 @@
 """
 Serialization of PENMAN graphs.
 """
-
+import locale
 from typing import Union, Iterable, Iterator, List, IO
 from pathlib import Path
 
@@ -241,7 +241,8 @@ def _encode(g: Graph,
 
 
 def _load(source: FileOrFilename,
-          model: Model = None) -> List[Graph]:
+          model: Model = None,
+          encoding: str = locale.getpreferredencoding()) -> List[Graph]:
     """
     Deserialize a list of PENMAN-encoded graphs from *source*.
 
@@ -253,7 +254,7 @@ def _load(source: FileOrFilename,
     """
     codec = PENMANCodec(model=model)
     if isinstance(source, (str, Path)):
-        with open(source) as fh:
+        with open(source, encoding=encoding) as fh:
             return list(codec.iterdecode(fh))
     else:
         assert hasattr(source, 'read')
@@ -279,7 +280,8 @@ def _dump(graphs: Iterable[Graph],
           file: FileOrFilename,
           model: Model = None,
           indent: Union[int, bool] = -1,
-          compact: bool = False) -> None:
+          compact: bool = False,
+          encoding: str = locale.getpreferredencoding()) -> None:
     """
     Serialize each graph in *graphs* to PENMAN and write to *file*.
 
@@ -292,7 +294,7 @@ def _dump(graphs: Iterable[Graph],
     """
     codec = PENMANCodec(model=model)
     if isinstance(file, (str, Path)):
-        with open(file, 'w') as fh:
+        with open(file, 'w', encoding=encoding) as fh:
             _dump_stream(fh, graphs, codec, indent, compact)
     else:
         assert hasattr(file, 'write')

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,13 @@ with open(os.path.join(base_dir, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 about = {}
-with open(os.path.join(base_dir, "penman", "__about__.py")) as f:
+with open(os.path.join(base_dir, "penman", "__about__.py"), encoding='utf-8') as f:
     exec(f.read(), about)
 
 # thanks: https://snarky.ca/clarifying-pep-518/
 docs_requirements = os.path.join(base_dir, 'docs', 'requirements.txt')
 if os.path.isfile(docs_requirements):
-    with open(docs_requirements) as f:
+    with open(docs_requirements, encoding='utf-8') as f:
         docs_require = f.readlines()
 else:
     docs_require = []

--- a/tests/test_penman.py
+++ b/tests/test_penman.py
@@ -31,13 +31,13 @@ def test_loads():
 
 def test_load(tmp_path):
     f = tmp_path / 'test_load1'
-    f.write_text('(a / alpha)(b / beta)')
+    f.write_text('(a / alpha)(b / beta)', encoding='utf-8')
     gs = load(f)
     assert len(gs) == 2
     assert gs[0].triples == [('a', ':instance', 'alpha')]
     assert gs[1].triples == [('b', ':instance', 'beta')]
 
-    with f.open() as fh:
+    with f.open(encoding='utf-8') as fh:
         assert load(fh) == gs
 
 
@@ -54,9 +54,9 @@ def test_dump(tmp_path):
     f1 = tmp_path / 'test_dump1'
     f2 = tmp_path / 'test_dump2'
     dump(gs, f1)
-    with f2.open('w') as fh:
+    with f2.open('w', encoding='utf-8') as fh:
         dump(gs, fh)
-    assert f1.read_text() == f2.read_text()
+    assert f1.read_text(encoding='utf-8') == f2.read_text(encoding='utf-8')
 
 
 def test_parse():


### PR DESCRIPTION
Currently, some issues may be experienced by Windows users because of encoding issues. The reason is that Windows unfortunately still relies on cp1252 rather than utf-8. This PR explicitly sets utf-8 where applicable (set-up files) and allows user-defined encoding elsewhere (in the `codec` module as well as the command line script).

Tests completed successfully.

Closes #109 

