### PR TITLE
Add containment for trees and graphs

### DIFF
--- a/penman/graph.py
+++ b/penman/graph.py
@@ -173,16 +173,29 @@ class Graph(object):
         else:
             return NotImplemented
 
-    def __contains__(self, item: Union[str, Triple, Tuple[str, str, str]]):
+    def __contains__(
+        self, item: Union[Triple, Tuple[Constant, Constant, Constant]]
+    ):
         """
-        Containment checking of either a string or a triple (tuple). In the case of a
-        string, will return True if the given string is a terminal instance in the graph.
-        If a triple or tuple, will return True if the triple exists in self.triples.
+        Containment checking of a triple (or tuple). If the input `item`
+        contains `None`, that part will be ignored. Examples:
+
+        (None, ":ARG9", None) in g  # any triple with role :ARG9
+        (None, ":instance", "foo") in g  # any instance with concept "foo"
         """
-        if isinstance(item, tuple):
+        if None in item:
+            for triple in self.triples:
+                triple_matches = True
+                # Compare non-None items of the given item with every one
+                # of graph's triples
+                for new_item, existing_item in zip(item, triple):
+                    if new_item is not None and new_item != existing_item:
+                        triple_matches = False
+                if triple_matches:
+                    return True
+            return False
+        else:
             return item in self.triples
-        terminals = {t[2] for t in self.instances()}
-        return item in terminals
 
     @property
     def top(self) -> Union[Variable, None]:

--- a/penman/graph.py
+++ b/penman/graph.py
@@ -179,13 +179,10 @@ class Graph(object):
         string, will return True if the given string is a terminal instance in the graph.
         If a triple or tuple, will return True if the triple exists in self.triples.
         """
-        if isinstance(item, str):
-            terminals = [t[2] for t in self.instances()]
-            return item in terminals
-        elif isinstance(item, tuple):
+        if isinstance(item, tuple):
             return item in self.triples
-        else:
-            raise NotImplemented
+        terminals = {t[2] for t in self.instances()}
+        return item in terminals
 
     @property
     def top(self) -> Union[Variable, None]:

--- a/penman/graph.py
+++ b/penman/graph.py
@@ -4,7 +4,16 @@
 Data structures for Penman graphs and triples.
 """
 
-from typing import (Union, Optional, Mapping, List, Dict, Set, NamedTuple, Tuple)
+from typing import (
+    Union,
+    Optional,
+    Mapping,
+    List,
+    Dict,
+    Set,
+    NamedTuple,
+    Tuple
+)
 from collections import defaultdict
 import copy
 

--- a/penman/graph.py
+++ b/penman/graph.py
@@ -4,7 +4,7 @@
 Data structures for Penman graphs and triples.
 """
 
-from typing import (Union, Optional, Mapping, List, Dict, Set, NamedTuple)
+from typing import (Union, Optional, Mapping, List, Dict, Set, NamedTuple, Tuple)
 from collections import defaultdict
 import copy
 
@@ -172,6 +172,20 @@ class Graph(object):
             return self
         else:
             return NotImplemented
+
+    def __contains__(self, item: Union[str, Triple, Tuple[str, str, str]]):
+        """
+        Containment checking of either a string or a triple (tuple). In the case of a
+        string, will return True if the given string is a terminal instance in the graph.
+        If a triple or tuple, will return True if the triple exists in self.triples.
+        """
+        if isinstance(item, str):
+            terminals = [t[2] for t in self.instances()]
+            return item in terminals
+        elif isinstance(item, tuple):
+            return item in self.triples
+        else:
+            raise NotImplemented
 
     @property
     def top(self) -> Union[Variable, None]:

--- a/penman/tree.py
+++ b/penman/tree.py
@@ -40,6 +40,16 @@ class Tree:
         s = _format(self.node, 2)
         return f'Tree(\n  {s})'
 
+    def __contains__(self, item: str):
+        """
+        Test whether a given string is part of the tree as a terminal instance node.
+        """
+        if isinstance(item, str):
+            terminals = [target for _, (role, target) in self.walk() if role == "/" and is_atomic(target)]
+            return item in terminals
+        else:
+            raise NotImplemented
+
     def nodes(self) -> List[Node]:
         """
         Return the nodes in the tree as a flat list.

--- a/penman/tree.py
+++ b/penman/tree.py
@@ -40,16 +40,6 @@ class Tree:
         s = _format(self.node, 2)
         return f'Tree(\n  {s})'
 
-    def __contains__(self, item: str):
-        """
-        Test whether a given string is part of the tree as a terminal instance node.
-        """
-        if isinstance(item, str):
-            terminals = [target for _, (role, target) in self.walk() if role == "/" and is_atomic(target)]
-            return item in terminals
-        else:
-            raise NotImplemented
-
     def nodes(self) -> List[Node]:
         """
         Return the nodes in the tree as a flat list.

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -108,11 +108,13 @@ class TestGraph(object):
                    ('a', ':ARG', 'b'),
                    ('b', ':instance', 'beta')])
 
-        assert "alpha" in g
-        assert "beta" in g
-        assert "b" not in g
-        assert ('a', ':ARG', 'b') in g
-        assert Triple('b', ':instance', 'beta') in g
+        assert Triple(None, ':instance', 'beta') in g
+        assert Triple('b', None, 'beta') in g
+        assert Triple('b', ':instance', None) in g
+        # No match
+        assert Triple('b', ':instance', 'alpha') not in g
+        # Regular tuples
+        assert ('b', ':instance', None) in g
 
     def test_top(self, x1):
         assert Graph([('a', ':instance', None)]).top == 'a'

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import penman
+from penman import Triple
 
 Graph = penman.Graph
 
@@ -101,6 +102,17 @@ class TestGraph(object):
         assert g.triples == [('b', ':instance', 'beta')]
         assert g.top == 'b'
         assert g is original
+
+    def test__contains__(self):
+        g = Graph([('a', ':instance', 'alpha'),
+                   ('a', ':ARG', 'b'),
+                   ('b', ':instance', 'beta')])
+
+        assert "alpha" in g
+        assert "beta" in g
+        assert "b" not in g
+        assert ('a', ':ARG', 'b') in g
+        assert Triple('b', ':instance', 'beta') in g
 
     def test_top(self, x1):
         assert Graph([('a', ':instance', None)]).top == 'a'

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from penman import tree
@@ -47,6 +46,14 @@ class TestTree:
         assert t.node == simple_node
         assert t.metadata == {'snt': 'Alpha.'}
 
+    def test__contains__(self):
+        t = tree.Tree(('a', [('/', 'alpha'), (':ARG', ('b', [('/', 'beta')]))]))
+
+        assert "alpha" in t
+        assert "beta" in t
+        assert "b" not in t
+        assert ":ARG" not in t
+
     def test_nodes(self, one_arg_node, reentrant):
         t = tree.Tree(one_arg_node)
         assert t.nodes() == [one_arg_node, ('b', [('/', 'beta')])]
@@ -86,7 +93,6 @@ class TestTree:
         ]
 
     def test_reset_variables(self, one_arg_node, reentrant, var_instance):
-
         def _vars(t):
             return [v for v, _ in t.nodes()]
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -46,14 +46,6 @@ class TestTree:
         assert t.node == simple_node
         assert t.metadata == {'snt': 'Alpha.'}
 
-    def test__contains__(self):
-        t = tree.Tree(('a', [('/', 'alpha'), (':ARG', ('b', [('/', 'beta')]))]))
-
-        assert "alpha" in t
-        assert "beta" in t
-        assert "b" not in t
-        assert ":ARG" not in t
-
     def test_nodes(self, one_arg_node, reentrant):
         t = tree.Tree(one_arg_node)
         assert t.nodes() == [one_arg_node, ('b', [('/', 'beta')])]


### PR DESCRIPTION
Added simple containment `__contains__` for graphs and trees. Tests are added, too.

For graphs:
- `str`: whether a given string is part of the graph as a terminal instance
- tuple (or Triple): whether it is part of self.triples
- `NotImplemented` in other cases - so testing for subgraphs is not yet implement. Open to suggestions how to do that though. I was thinking of just doing triplet matching, but perhaps we want to be less strict and allow a match with different varnames as well?

For trees:
- `str`: whether a given string is part of the tree as a terminal instance

I get the terminal nodes in the tree like this:

```python
terminals = [target for _, (role, target) in self.walk() if role == "/" and is_atomic(target)]
```

which feels elaborate so perhaps there is a simpler way? Happy to change it if there is!

closes #10 (partially, at least, since subgraph testing is not included in this PR)